### PR TITLE
Remove test dependency on HTTP

### DIFF
--- a/js-flot.cabal
+++ b/js-flot.cabal
@@ -61,5 +61,4 @@ test-suite js-flot-test
     type: exitcode-stdio-1.0
     main-is: Test.hs
     build-depends:
-        base == 4.*,
-        HTTP
+        base == 4.*


### PR DESCRIPTION
Unless I misunderstand the test, it only uses local file access. The HTTP dependency was probably copied from js-jquery, which does use internet resources.
